### PR TITLE
fix: Could not find a declaration file for module 'webext-zustand'

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs"
   },


### PR DESCRIPTION
Fixes the following error:
```
Could not find a declaration file for module 'webext-zustand'. '/myproject/node_modules/webext-zustand/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/myproject/node_modules/webext-zustand/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'webext-zustand' library may need to update its package.json or typings.ts(7016)
```

More info: https://github.com/microsoft/TypeScript/issues/52363